### PR TITLE
docs: unify CourseBook branding

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Simple Logger
 
-A lightweight, flexible logging system for ContentSmith that supports namespace-based logging with different log levels.
+A lightweight, flexible logging system for CourseBook that supports namespace-based logging with different log levels.
 
 ## Features
 

--- a/packages/simple-logger/README.md
+++ b/packages/simple-logger/README.md
@@ -1,6 +1,6 @@
 # Simple Logger
 
-A lightweight, flexible logging system for ContentSmith that supports namespace-based logging with different log levels.
+A lightweight, flexible logging system for CourseBook that supports namespace-based logging with different log levels.
 
 > [!TIP]
 > Refer to this package's docs ([source](../../docs/index.md) or [website](https://proj-coursebook.github.io/simple-logger/)) for how to use it.


### PR DESCRIPTION
## Summary
- fix ContentSmith references to CourseBook in docs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a37068388832c87c22f7fe90e6b00