### PR TITLE
fix: handle null values correctly

### DIFF
--- a/packages/simple-logger/src/index.ts
+++ b/packages/simple-logger/src/index.ts
@@ -136,7 +136,7 @@ export class LogManagerImpl implements LogManager {
       logMethod(
         prefix,
         ...args.map((arg) =>
-          typeof arg === "object" ? JSON.stringify(arg, null, 2) : arg,
+          typeof arg === "object" && arg !== null ? JSON.stringify(arg, null, 2) : arg,
         ),
       );
     }

--- a/packages/simple-logger/tests/index.test.ts
+++ b/packages/simple-logger/tests/index.test.ts
@@ -162,5 +162,17 @@ describe("LogManager", () => {
         JSON.stringify(testObj, null, 2),
       );
     });
+
+    it("should log null without quotes", () => {
+      const logger = logManager.getLogger("test");
+
+      logger.info("value", null);
+
+      expect(consoleMock.log).toHaveBeenCalledWith(
+        "[INFO] [test]",
+        "value",
+        null,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- log null values correctly without stringifying
- add unit test to ensure nulls are logged properly

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a38e77cbc832caa529d39da77960a