### PR TITLE
Add regex precedence test

### DIFF
--- a/packages/simple-logger/tests/index.test.ts
+++ b/packages/simple-logger/tests/index.test.ts
@@ -120,6 +120,17 @@ describe("LogManager", () => {
       );
       expect(consoleMock.log).toHaveBeenCalledWith("[INFO] [test:123]", "info");
     });
+
+    it("should prioritize regex level over wildcard", () => {
+      const logger = logManager.getLogger("test:42");
+
+      logManager.setLogLevel(/test:\d+/, "info");
+      logManager.setLogLevel("*", "error");
+
+      logger.info("info");
+
+      expect(consoleMock.log).toHaveBeenCalledWith("[INFO] [test:42]", "info");
+    });
   });
 
   describe("Enable/Disable", () => {


### PR DESCRIPTION
## Summary
- add test to verify regex log levels override wildcard settings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a3ab63da8832cbedfed81a597b248